### PR TITLE
Fix duplicate figure label

### DIFF
--- a/src/tex/ms.tex
+++ b/src/tex/ms.tex
@@ -166,7 +166,7 @@ The different telescopes and filters are indicated in the legend.
 %
 Each light curve is offset vertically by 0.8.
               }
-        \label{fig:allphot}
+        \label{fig:eclipse_overview}
         \script{plot_eclipse_overview2.py}
     \end{centering}
 \end{figure*}


### PR DESCRIPTION
There's a duplicate figure label in your manuscript:

https://github.com/mkenworthy/ASASSN-21qj-debris/blob/7a4cd78613780623e042a18cbf6069b4325154ec/src/tex/ms.tex#L169

and

https://github.com/mkenworthy/ASASSN-21qj-debris/blob/7a4cd78613780623e042a18cbf6069b4325154ec/src/tex/ms.tex#L260

This results in the first figure/script pair getting overwritten when `showyourwork` builds the article dependency graph (since things are indexed based on labels), which is causing `eclipse_overview2.pdf` to not get generated.

Original issue [here](https://github.com/showyourwork/showyourwork/issues/172).